### PR TITLE
feature/dsrc in memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# The next three lines of code ensures Linux binary executable files are ignored
+# Ignore everything
+*
+# DO NOT blacklist any directories
+!*/
+# DO NOT blacklist any filename with an extension
+!*.*
 .DS_Store
 *.o
 bin/

--- a/include/dsrc/DsrcInMemory.h
+++ b/include/dsrc/DsrcInMemory.h
@@ -1,0 +1,11 @@
+#ifndef H_DSRCINMEMORY
+#define H_DSRCINMEMORY
+
+namespace dsrc{
+  namespace comp {
+    using namespace core;
+    using namespace fq;
+  }
+}
+
+#endif

--- a/include/dsrc/DsrcInMemory.h
+++ b/include/dsrc/DsrcInMemory.h
@@ -6,7 +6,7 @@
 #include "../../src/Fastq.h"
 
 namespace dsrc{
-  namespace comp {
+  namespace ext {
 
     /**
      * Utilizes the implementation of DsrcFileReader to read the binary contents

--- a/include/dsrc/DsrcInMemory.h
+++ b/include/dsrc/DsrcInMemory.h
@@ -7,8 +7,6 @@
 
 namespace dsrc{
   namespace comp {
-    using namespace core;
-    using namespace fq;
 
     /**
      * Utilizes the implementation of DsrcFileReader to read the binary contents
@@ -28,9 +26,9 @@ namespace dsrc{
         std::string getNextChunk();
 
       private:
-        DsrcFileReader* reader = NULL;
-        DsrcDataChunk* dsrcChunk = NULL;
-        FastqDataChunk* fastqChunk = NULL;
+        comp::DsrcFileReader* reader = NULL;
+        comp::DsrcDataChunk* dsrcChunk = NULL;
+        fq::FastqDataChunk* fastqChunk = NULL;
     };
   }
 }

--- a/include/dsrc/DsrcInMemory.h
+++ b/include/dsrc/DsrcInMemory.h
@@ -1,10 +1,37 @@
 #ifndef H_DSRCINMEMORY
 #define H_DSRCINMEMORY
 
+#include "../../src/DsrcFile.h"
+#include "../../src/DsrcIo.h"
+#include "../../src/Fastq.h"
+
 namespace dsrc{
   namespace comp {
     using namespace core;
     using namespace fq;
+
+    /**
+     * Utilizes the implementation of DsrcFileReader to read the binary contents
+     * of a .dsrc file into memory and return the uncompressed FASTQ content as
+     * a string
+     *
+     * This allows the contents of a .dsrc file to be uncompressed without
+     * needing to write the contents to a file, which can be beneficial when
+     * concatenating multiple .dsrc files into a single concatenated .fastq file
+     * with limited hard disk space (i.e. no longer needing to uncompress each
+     * .dsrc file into temporary .fastq files before concatenation)
+     */
+    class DsrcInMemory {
+      public:
+        DsrcInMemory(const std::string& dsrcFilename_);
+        ~DsrcInMemory();
+        std::string getNextChunk();
+
+      private:
+        DsrcFileReader* reader = NULL;
+        DsrcDataChunk* dsrcChunk = NULL;
+        FastqDataChunk* fastqChunk = NULL;
+    };
   }
 }
 

--- a/src/DsrcInMemory.cpp
+++ b/src/DsrcInMemory.cpp
@@ -11,7 +11,7 @@
 #include <iostream>
 
 namespace dsrc{
-  namespace comp {
+  namespace ext {
     /**
      * Creates a pointer to the given .dsrc file to read the buffer contents
      * in chunks

--- a/src/DsrcInMemory.cpp
+++ b/src/DsrcInMemory.cpp
@@ -1,0 +1,8 @@
+#include "../include/dsrc/DsrcInMemory.h"
+
+namespace dsrc{
+  namespace comp {
+    using namespace core;
+    using namespace fq;
+  }
+}

--- a/src/DsrcInMemory.cpp
+++ b/src/DsrcInMemory.cpp
@@ -12,9 +12,6 @@
 
 namespace dsrc{
   namespace comp {
-    using namespace core;
-    using namespace fq;
-
     /**
      * Creates a pointer to the given .dsrc file to read the buffer contents
      * in chunks
@@ -25,10 +22,10 @@ namespace dsrc{
      */
     DsrcInMemory::DsrcInMemory(const std::string& dsrcFilename_) {
       try {
-        reader = new DsrcFileReader();
+        reader = new comp::DsrcFileReader();
         reader->StartDecompress(dsrcFilename_);
-        dsrcChunk = new DsrcDataChunk(DsrcDataChunk::DefaultBufferSize);
-        fastqChunk = new FastqDataChunk(FastqDataChunk::DefaultBufferSize);
+        dsrcChunk = new comp::DsrcDataChunk(comp::DsrcDataChunk::DefaultBufferSize);
+        fastqChunk = new fq::FastqDataChunk(fq::FastqDataChunk::DefaultBufferSize);
       } catch (const DsrcException& e_) {
         /**
          * @todo Implement IsError() functionality? Extend from IDsrcOperator?
@@ -60,12 +57,12 @@ namespace dsrc{
      * content of the input file
      */
     std::string DsrcInMemory::getNextChunk(){
-      BlockCompressor superblock(
+      comp::BlockCompressor superblock(
         reader->GetDatasetType(),
         reader->GetCompressionSettings()
       );
       if (reader->ReadNextChunk(dsrcChunk)) {
-        BitMemoryReader bitMemory(
+        core::BitMemoryReader bitMemory(
           dsrcChunk->data.Pointer(),
           dsrcChunk->size
         );

--- a/src/DsrcInMemory.cpp
+++ b/src/DsrcInMemory.cpp
@@ -1,8 +1,52 @@
 #include "../include/dsrc/DsrcInMemory.h"
 
+#include "DsrcFile.h"
+#include "DsrcIo.h"
+#include "Buffer.h"
+#include "Fastq.h"
+
+#include <iostream>
+
 namespace dsrc{
   namespace comp {
     using namespace core;
     using namespace fq;
+
+    /**
+     * Creates a pointer to the given .dsrc file to read the buffer contents
+     * in chunks
+     *
+     * Allocates memory for dsrcChunk* for the buffer to be loaded into memory,
+     * allocates memory for fastqChunk* for the decompressed buffer contents to
+     * be loaded into memory
+     */
+    DsrcInMemory::DsrcInMemory(const std::string& dsrcFilename_) {
+      try {
+        reader = new DsrcFileReader();
+        reader->StartDecompress(dsrcFilename_);
+        dsrcChunk = new DsrcDataChunk(DsrcDataChunk::DefaultBufferSize);
+        fastqChunk = new FastqDataChunk(FastqDataChunk::DefaultBufferSize);
+      } catch (const DsrcException& e_) {
+        /**
+         * @todo Implement IsError() functionality? Extend from IDsrcOperator?
+         */
+        std::cerr << e_.what() << std::endl;
+        exit(1);
+      }
+    }
+
+    /**
+     * Removes all contents from memory allocated for dsrcChunk and fastqChunk,
+     * closes the decompression fileStream, and frees up all memory allocated
+     * for each pointer
+     */
+    DsrcInMemory::~DsrcInMemory() {
+      dsrcChunk->Reset();
+      fastqChunk->Reset();
+      reader->FinishDecompress();
+      delete dsrcChunk;
+      delete fastqChunk;
+      delete reader;
+    }
   }
 }

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,6 +11,7 @@ APP_OBJS = DsrcOperator.o \
 	DsrcWorker.o \
 	DsrcIo.o \
 	DsrcFile.o \
+	DsrcInMemory.o \
 	BlockCompressor.o \
 	DnaModelerHuffman.o \
 	QualityPositionModeler.o \


### PR DESCRIPTION
Add a class that allows the contents of a `.dsrc` to be stored in memory, rather than immediately being written to a file.