### PR TITLE
feature/python open dsrc in chunks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 !*/
 # DO NOT blacklist any filename with an extension
 !*.*
+!Jamroot
+!Jamfile
 .DS_Store
 *.o
 bin/

--- a/py/Interface.cpp
+++ b/py/Interface.cpp
@@ -313,6 +313,7 @@ class PyDsrcReadInMemory {
 			/**
 			 * @todo Implement TCheckError usage with DsrcInMemory
 			 */
+			dsrcInMemory = NULL;
 		}
 
 		/**
@@ -345,8 +346,12 @@ class PyDsrcReadInMemory {
 			return line;
 		}
 
+		bool closed() {
+			return dsrcInMemory == NULL;
+		}
+
 	private:
-		DsrcInMemory * dsrcInMemory;
+		DsrcInMemory * dsrcInMemory = NULL;
 		std::queue<std::string> chunk;
 
 		/**
@@ -436,6 +441,7 @@ BOOST_PYTHON_MODULE(pydsrc)
 		.def("open", &PyDsrcReadInMemory::Open)
 		.def("readline", &PyDsrcReadInMemory::readline)
 		.def("close", &PyDsrcReadInMemory::Close)
+		.def("closed", &PyDsrcReadInMemory::closed)
 	;
 }
 

--- a/py/Interface.cpp
+++ b/py/Interface.cpp
@@ -383,9 +383,9 @@ BOOST_PYTHON_MODULE(pydsrc)
 	;
 
 	boo::class_<PyDsrcReadInMemory, boost::noncopyable>("DsrcReadInMemory")
-		.def("Open", &PyDsrcReadInMemory::Open)
+		.def("open", &PyDsrcReadInMemory::Open)
 		.def("readline", &PyDsrcReadInMemory::readline)
-		.def("Close", &PyDsrcReadInMemory::Close)
+		.def("close", &PyDsrcReadInMemory::Close)
 	;
 }
 

--- a/py/Interface.cpp
+++ b/py/Interface.cpp
@@ -19,6 +19,9 @@
 #include <boost/python/overloads.hpp>
 
 #include <Python.h>
+#include <string>
+#include <sstream>
+#include <vector>
 
 #include "../include/dsrc/Globals.h"
 #include "../include/dsrc/FastqRecord.h"
@@ -321,6 +324,29 @@ class PyDsrcReadInMemory {
 
 	private:
 		DsrcInMemory * dsrcInMemory;
+
+		/**
+		 * C++ does not have a built-in std::string.split() function that tokenizes
+		 * strings on a given delimiter
+		 *
+		 * This implementation is based off of a Stack Overflow implementation:
+		 *
+		 * https://stackoverflow.com/a/236803/10491481
+		 */
+		template <typename Out>
+		void split(const std::string &s, char delim, Out result) {
+			std::istringstream iss(s);
+			std::string item;
+			while (std::getline(iss, item, delim)) {
+				*result++ = item;
+			}
+		}
+
+		std::vector<std::string> split(const std::string &s, char delim) {
+			std::vector<std::string> elems;
+			split(s, delim, std::back_inserter(elems));
+			return elems;
+		}
 
 		std::string ReadNextChunk() {
 			return dsrcInMemory->getNextChunk();

--- a/py/Interface.cpp
+++ b/py/Interface.cpp
@@ -312,12 +312,19 @@ class PyDsrcReadInMemory {
 			 */
 		}
 
-		std::string ReadNextChunk() {
-			return dsrcInMemory->getNextChunk();
+		/**
+		 * @todo Return a line from the current chunk
+		 */
+		std::string readline() {
+			return ReadNextChunk();
 		}
 
 	private:
 		DsrcInMemory * dsrcInMemory;
+
+		std::string ReadNextChunk() {
+			return dsrcInMemory->getNextChunk();
+		}
 };
 
 
@@ -377,7 +384,7 @@ BOOST_PYTHON_MODULE(pydsrc)
 
 	boo::class_<PyDsrcReadInMemory, boost::noncopyable>("DsrcReadInMemory")
 		.def("Open", &PyDsrcReadInMemory::Open)
-		.def("ReadNextChunk", &PyDsrcReadInMemory::ReadNextChunk)
+		.def("readline", &PyDsrcReadInMemory::readline)
 		.def("Close", &PyDsrcReadInMemory::Close)
 	;
 }

--- a/py/Interface.cpp
+++ b/py/Interface.cpp
@@ -316,14 +316,38 @@ class PyDsrcReadInMemory {
 		}
 
 		/**
-		 * @todo Return a line from the current chunk
+		 * Returns the next line of the opened .dsrc file
+		 *
+		 * Retrieves chunks of the .dsrc file by calling ReadNextChunk, and storing
+		 * each line of the chunk in a Queue
+		 *
+		 * The Queue is accessed for the next line until the Queue is empty, at
+		 * which point the next chunk is retrieved
 		 */
 		std::string readline() {
-			return ReadNextChunk();
+			if (chunk.empty()) {
+				std::string lines = ReadNextChunk();
+				std::vector<std::string> split_lines = split(lines, '\n');
+				if (split_lines.capacity() == 0) {
+					// End of file has been reached
+					return lines;
+				}
+				for (
+					std::vector<std::string>::iterator it = split_lines.begin();
+					it != split_lines.end();
+					++it
+				) {
+					chunk.push(*it + "\n");
+				}
+			}
+			std::string line = chunk.front();
+			chunk.pop();
+			return line;
 		}
 
 	private:
 		DsrcInMemory * dsrcInMemory;
+		std::queue<std::string> chunk;
 
 		/**
 		 * C++ does not have a built-in std::string.split() function that tokenizes

--- a/py/Interface.cpp
+++ b/py/Interface.cpp
@@ -25,6 +25,7 @@
 #include "../include/dsrc/FastqFile.h"
 #include "../include/dsrc/DsrcModule.h"
 #include "../include/dsrc/DsrcArchive.h"
+#include "../include/dsrc/DsrcInMemory.h"
 
 namespace dsrc
 {
@@ -295,6 +296,29 @@ private:
 	DsrcArchiveRecordsReader reader;
 };
 
+class PyDsrcReadInMemory {
+	public:
+		void Open(const std::string& inDsrcFilename_) {
+			dsrcInMemory = new DsrcInMemory(inDsrcFilename_);
+			/**
+			 * @todo Implement TCheckError usage with DsrcInMemory
+			 */
+		}
+
+		void Close() {
+			delete dsrcInMemory;
+			/**
+			 * @todo Implement TCheckError usage with DsrcInMemory
+			 */
+		}
+
+		std::string ReadNextChunk() {
+			return dsrcInMemory->getNextChunk();
+		}
+
+	private:
+		DsrcInMemory * dsrcInMemory;
+};
 
 
 BOOST_PYTHON_MODULE(pydsrc)
@@ -349,6 +373,12 @@ BOOST_PYTHON_MODULE(pydsrc)
 		.def("StartDecompress", &PyDsrcArchiveRecordsReader::StartDecompress)
 		.def("ReadNextRecord", &PyDsrcArchiveRecordsReader::ReadNextRecord)
 		.def("FinishDecompress", &PyDsrcArchiveRecordsReader::FinishDecompress)
+	;
+
+	boo::class_<PyDsrcReadInMemory, boost::noncopyable>("DsrcReadInMemory")
+		.def("Open", &PyDsrcReadInMemory::Open)
+		.def("ReadNextChunk", &PyDsrcReadInMemory::ReadNextChunk)
+		.def("Close", &PyDsrcReadInMemory::Close)
 	;
 }
 

--- a/py/Jamroot
+++ b/py/Jamroot
@@ -24,7 +24,7 @@ project
 # Extension modules
 #
 python-extension pydsrc
-	: Interface.cpp ../src/DsrcModule.cpp ../src/DsrcArchive.cpp ../src/FastqFile.cpp ../src/RecordsBlockCompressor.cpp ../src/DsrcWorker.cpp ../src/DsrcIo.cpp ../src/DsrcFile.cpp ../src/DsrcOperator.cpp ../src/BlockCompressor.cpp ../src/FastqIo.cpp ../src/RecordsProcessor.cpp ../src/FastqParser.cpp ../src/FastqStream.cpp ../src/FileStream.cpp ../src/StdStream.cpp ../src/TagModeler.cpp ../src/DnaModelerHuffman.cpp ../src/QualityPositionModeler.cpp ../src/QualityRLEModeler.cpp ../src/huffman.cpp
+	: Interface.cpp ../src/DsrcModule.cpp ../src/DsrcArchive.cpp ../src/FastqFile.cpp ../src/RecordsBlockCompressor.cpp ../src/DsrcWorker.cpp ../src/DsrcIo.cpp ../src/DsrcFile.cpp ../src/DsrcOperator.cpp ../src/BlockCompressor.cpp ../src/FastqIo.cpp ../src/RecordsProcessor.cpp ../src/FastqParser.cpp ../src/FastqStream.cpp ../src/FileStream.cpp ../src/StdStream.cpp ../src/TagModeler.cpp ../src/DnaModelerHuffman.cpp ../src/QualityPositionModeler.cpp ../src/QualityRLEModeler.cpp ../src/huffman.cpp ../src/DsrcInMemory.cpp
 
 #
 # Important!


### PR DESCRIPTION
Add Python module using `Boost` to allow the Python compatible version of `DSRC` to utilize the logic implemented in the [`DsrcInMemory`](https://github.com/CorreyL/DSRC/blob/devel/src/DsrcInMemory.cpp) class.