### PR TITLE
Feature/python dsrc in memory error check

### DIFF
--- a/include/dsrc/DsrcInMemory.h
+++ b/include/dsrc/DsrcInMemory.h
@@ -32,7 +32,7 @@ namespace dsrc{
         comp::DsrcFileReader* reader = NULL;
         comp::DsrcDataChunk* dsrcChunk = NULL;
         fq::FastqDataChunk* fastqChunk = NULL;
-        std::string errorMsg = "";
+        std::string errorMsg;
     };
   }
 }

--- a/include/dsrc/DsrcInMemory.h
+++ b/include/dsrc/DsrcInMemory.h
@@ -24,11 +24,15 @@ namespace dsrc{
         DsrcInMemory(const std::string& dsrcFilename_);
         ~DsrcInMemory();
         std::string getNextChunk();
+        bool IsError() const;
+        void AddError(const std::string& err_);
+        void ClearError();
 
       private:
         comp::DsrcFileReader* reader = NULL;
         comp::DsrcDataChunk* dsrcChunk = NULL;
         fq::FastqDataChunk* fastqChunk = NULL;
+        std::string errorMsg = "";
     };
   }
 }

--- a/include/dsrc/DsrcInMemory.h
+++ b/include/dsrc/DsrcInMemory.h
@@ -27,6 +27,7 @@ namespace dsrc{
         bool IsError() const;
         void AddError(const std::string& err_);
         void ClearError();
+        std::string GetError();
 
       private:
         comp::DsrcFileReader* reader = NULL;

--- a/py/Interface.cpp
+++ b/py/Interface.cpp
@@ -70,6 +70,16 @@ void TCheckError(_T& obj_)
 	}
 }
 
+template <class _T>
+void TCheckPtrError(_T*& obj_)
+{
+	if (obj_->IsError())
+	{
+		std::string err = obj_->GetError();
+		obj_->ClearError();
+		throw PyException(err);
+	}
+}
 
 // Compression settings
 //
@@ -303,12 +313,12 @@ class PyDsrcReadInMemory {
 	public:
 		void Open(const std::string& inDsrcFilename_) {
 			dsrcInMemory = new DsrcInMemory(inDsrcFilename_);
-			TCheckError(dsrcInMemory);
+			TCheckPtrError(dsrcInMemory);
 		}
 
 		void Close() {
 			delete dsrcInMemory;
-			TCheckError(dsrcInMemory);
+			TCheckPtrError(dsrcInMemory);
 			dsrcInMemory = NULL;
 		}
 
@@ -375,7 +385,7 @@ class PyDsrcReadInMemory {
 
 		std::string ReadNextChunk() {
 			std::string chunk = dsrcInMemory->getNextChunk();
-			TCheckError(dsrcInMemory);
+			TCheckPtrError(dsrcInMemory);
 			return chunk;
 		}
 };

--- a/py/Interface.cpp
+++ b/py/Interface.cpp
@@ -303,16 +303,12 @@ class PyDsrcReadInMemory {
 	public:
 		void Open(const std::string& inDsrcFilename_) {
 			dsrcInMemory = new DsrcInMemory(inDsrcFilename_);
-			/**
-			 * @todo Implement TCheckError usage with DsrcInMemory
-			 */
+			TCheckError(dsrcInMemory);
 		}
 
 		void Close() {
 			delete dsrcInMemory;
-			/**
-			 * @todo Implement TCheckError usage with DsrcInMemory
-			 */
+			TCheckError(dsrcInMemory);
 			dsrcInMemory = NULL;
 		}
 
@@ -378,7 +374,9 @@ class PyDsrcReadInMemory {
 		}
 
 		std::string ReadNextChunk() {
-			return dsrcInMemory->getNextChunk();
+			std::string chunk = dsrcInMemory->getNextChunk();
+			TCheckError(dsrcInMemory);
+			return chunk;
 		}
 };
 

--- a/src/DsrcInMemory.cpp
+++ b/src/DsrcInMemory.cpp
@@ -37,9 +37,13 @@ namespace dsrc{
      * for each pointer
      */
     DsrcInMemory::~DsrcInMemory() {
-      dsrcChunk->Reset();
-      fastqChunk->Reset();
-      reader->FinishDecompress();
+      try {
+        dsrcChunk->Reset();
+        fastqChunk->Reset();
+        reader->FinishDecompress();
+      } catch (const DsrcException& e_) {
+        AddError(e_.what());
+      }
       delete dsrcChunk;
       delete fastqChunk;
       delete reader;

--- a/src/DsrcInMemory.cpp
+++ b/src/DsrcInMemory.cpp
@@ -77,5 +77,17 @@ namespace dsrc{
       }
       return "";
     }
+
+    bool DsrcInMemory::IsError() const {
+      return errorMsg.length() > 0;
+    }
+
+    void DsrcInMemory::AddError(const std::string& err_) {
+      errorMsg += "Error: " + err_ + '\n';
+    }
+
+    void DsrcInMemory::ClearError() {
+      errorMsg.clear();
+    }
   }
 }

--- a/src/DsrcInMemory.cpp
+++ b/src/DsrcInMemory.cpp
@@ -27,11 +27,7 @@ namespace dsrc{
         dsrcChunk = new comp::DsrcDataChunk(comp::DsrcDataChunk::DefaultBufferSize);
         fastqChunk = new fq::FastqDataChunk(fq::FastqDataChunk::DefaultBufferSize);
       } catch (const DsrcException& e_) {
-        /**
-         * @todo Implement IsError() functionality? Extend from IDsrcOperator?
-         */
-        std::cerr << e_.what() << std::endl;
-        exit(1);
+        AddError(e_.what());
       }
     }
 

--- a/src/DsrcInMemory.cpp
+++ b/src/DsrcInMemory.cpp
@@ -89,5 +89,9 @@ namespace dsrc{
     void DsrcInMemory::ClearError() {
       errorMsg.clear();
     }
+
+    std::string DsrcInMemory::GetError() {
+      return errorMsg;
+    }
   }
 }


### PR DESCRIPTION
Add error handling to `DsrcInMemory` class and the interface to the Python module when using the `DsrcInMemory` interface in Python.