### PR TITLE
Feature/python support with open

### DIFF
--- a/py/Interface.cpp
+++ b/py/Interface.cpp
@@ -365,13 +365,22 @@ class PyDsrcReadInMemory {
 		 * ensuring argument types match between C++ and Python when the function
 		 * is invoked
 		 */
-		void __exit__(
+		void __exit__no_error(
 			void* exceptionType,
 			void* exceptionValue,
 			void* traceback
 		) {
 			Close();
 		}
+
+		void __exit__error(
+			PyObject* exceptionType,
+			PyObject* exceptionValue,
+			PyObject* traceback
+		) {
+			Close();
+		}
+
 
 	private:
 		DsrcInMemory * dsrcInMemory = NULL;
@@ -468,7 +477,8 @@ BOOST_PYTHON_MODULE(pydsrc)
 		.def("close", &PyDsrcReadInMemory::Close)
 		.def("closed", &PyDsrcReadInMemory::closed)
 		.def("__enter__", &PyDsrcReadInMemory::__enter__)
-		.def("__exit__", &PyDsrcReadInMemory::__exit__)
+		.def("__exit__", &PyDsrcReadInMemory::__exit__no_error)
+		.def("__exit__", &PyDsrcReadInMemory::__exit__error)
 	;
 }
 

--- a/py/Interface.cpp
+++ b/py/Interface.cpp
@@ -356,6 +356,23 @@ class PyDsrcReadInMemory {
 			return dsrcInMemory == NULL;
 		}
 
+		PyDsrcReadInMemory __enter__() {
+			return *this;
+		}
+
+		/**
+		 * Arguments are typed as `void*` to simulate the `NoneType` type in Python,
+		 * ensuring argument types match between C++ and Python when the function
+		 * is invoked
+		 */
+		void __exit__(
+			void* exceptionType,
+			void* exceptionValue,
+			void* traceback
+		) {
+			Close();
+		}
+
 	private:
 		DsrcInMemory * dsrcInMemory = NULL;
 		std::queue<std::string> chunk;
@@ -445,11 +462,13 @@ BOOST_PYTHON_MODULE(pydsrc)
 		.def("FinishDecompress", &PyDsrcArchiveRecordsReader::FinishDecompress)
 	;
 
-	boo::class_<PyDsrcReadInMemory, boost::noncopyable>("DsrcReadInMemory")
+	boo::class_<PyDsrcReadInMemory>("DsrcReadInMemory")
 		.def("open", &PyDsrcReadInMemory::Open)
 		.def("readline", &PyDsrcReadInMemory::readline)
 		.def("close", &PyDsrcReadInMemory::Close)
 		.def("closed", &PyDsrcReadInMemory::closed)
+		.def("__enter__", &PyDsrcReadInMemory::__enter__)
+		.def("__exit__", &PyDsrcReadInMemory::__exit__)
 	;
 }
 


### PR DESCRIPTION
Add support for reading `.dsrc` files using the Python [`open`](https://docs.python.org/3/library/functions.html#open) function.