### PR TITLE
bugfix/close access to file

### DIFF
--- a/py/Interface.cpp
+++ b/py/Interface.cpp
@@ -312,9 +312,10 @@ private:
 
 class PyDsrcReadInMemory {
 	public:
-		void Open(const std::string& inDsrcFilename_) {
+		PyDsrcReadInMemory & Open(const std::string& inDsrcFilename_) {
 			dsrcInMemory = new DsrcInMemory(inDsrcFilename_);
 			TCheckPtrError(dsrcInMemory);
+			return *this;
 		}
 
 		void Close() {
@@ -473,7 +474,7 @@ BOOST_PYTHON_MODULE(pydsrc)
 	;
 
 	boo::class_<PyDsrcReadInMemory>("DsrcReadInMemory")
-		.def("open", &PyDsrcReadInMemory::Open)
+		.def("open", &PyDsrcReadInMemory::Open, boo::return_internal_reference<>())
 		.def("readline", &PyDsrcReadInMemory::readline)
 		.def("close", &PyDsrcReadInMemory::Close)
 		.def("closed", &PyDsrcReadInMemory::closed)

--- a/py/Interface.cpp
+++ b/py/Interface.cpp
@@ -17,6 +17,7 @@
 #include <boost/python/exception_translator.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <boost/python/overloads.hpp>
+#include <boost/python/return_internal_reference.hpp>
 
 #include <Python.h>
 #include <string>
@@ -356,7 +357,7 @@ class PyDsrcReadInMemory {
 			return dsrcInMemory == NULL;
 		}
 
-		PyDsrcReadInMemory __enter__() {
+		PyDsrcReadInMemory & __enter__() {
 			return *this;
 		}
 
@@ -476,7 +477,7 @@ BOOST_PYTHON_MODULE(pydsrc)
 		.def("readline", &PyDsrcReadInMemory::readline)
 		.def("close", &PyDsrcReadInMemory::Close)
 		.def("closed", &PyDsrcReadInMemory::closed)
-		.def("__enter__", &PyDsrcReadInMemory::__enter__)
+		.def("__enter__", &PyDsrcReadInMemory::__enter__, boo::return_internal_reference<>())
 		.def("__exit__", &PyDsrcReadInMemory::__exit__no_error)
 		.def("__exit__", &PyDsrcReadInMemory::__exit__error)
 	;

--- a/py/Interface.cpp
+++ b/py/Interface.cpp
@@ -341,6 +341,9 @@ class PyDsrcReadInMemory {
 		 * which point the next chunk is retrieved
 		 */
 		std::string readline() {
+			if (closed()) {
+				throw PyException("I/O operation on closed file.");
+			}
 			if (chunk.empty()) {
 				std::string lines = ReadNextChunk();
 				std::vector<std::string> split_lines = split(lines, '\n');

--- a/py/Interface.cpp
+++ b/py/Interface.cpp
@@ -322,6 +322,13 @@ class PyDsrcReadInMemory {
 			delete dsrcInMemory;
 			TCheckPtrError(dsrcInMemory);
 			dsrcInMemory = NULL;
+			/**
+			 * Create an empty queue<string> and swap it with `chunk` for an O(1)
+			 * operation to empty the queue of lines that were last read from the
+			 * `.dsrc` file
+			 */
+			std::queue<std::string> empty;
+			std::swap(chunk, empty);
 		}
 
 		/**


### PR DESCRIPTION
## Preamble

This PR concerns tightening up the logic around the functions `Open` and `Close`.

## Explanation

### `PyDsrcReadInMemory.Open`

Changes to `Open` ensures that more Pythonic approaches to using `pydsrc`, such as:

```python
# Illustrates how to print the first line of a `.dsrc` file using the
# `pydsrc` module, using the built-in `with` function
import pydsrc

module = pydsrc.DsrcReadInMemory()

with module.open("some.dsrc") as dsrc_file:
  dsrc_file.readline()
```

Is possible. Previous logic did not allow usage with the `with` keyword, since `__enter__` did not return the internal `PyDsrcReadInMemory` object, preventing usage of chained methods within the `with` block, such as `readline`.

### `PyDsrcReadInMemory.Close`

Changes to `Close` ensures that lines cannot be retrieved using `readline` after `Close` is invoked. Previous logic allowed for `readline` to (seemingly) continue to read lines from the file, but in actuality, it was possible for there to be lines stored in `std:queue` that `readline` was returning.

As such, I've added logic to `Close` to ensure the `queue` is emptied by invoking `std::swap` with an empty instance of `std::queue` in 019843b958be047ef5c950a61728cb057b4735cd, as per the suggestion from this Stack Overflow post:

https://stackoverflow.com/a/709161/10491481

It's worth noting that since `std::queue<std::string> empty` is defined within the local scope of `Close`, I am under the impression that its memory contents will be cleared when the program leaves the invocation of the function.

I've also added a `closed()` check for `readline` in 22b7299c45c3552e7e64c6bf80524d08b13b6313, as another measure to ensure I/O is not attempted on a closed file, preventing a possible segmentation fault from occurring.